### PR TITLE
make Bob extensible using a simple mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Detailed examples of how to interact with Bob are given in these notebooks:
 * [Browsing folders](https://github.com/haesleinhuepf/bia-bob/blob/main/demo/browsing_folders.ipynb)
 * [Interactive image stack viewing](https://github.com/haesleinhuepf/bia-bob/blob/main/demo/interactive_stackview.ipynb)
 * [For developers](https://github.com/haesleinhuepf/bia-bob/blob/main/demo/for_developers.ipynb)
+* [Extensibility](https://github.com/haesleinhuepf/bia-bob/blob/main/demo/extensibility.ipynb)
 
 You can initialize Bob like this:
 ```

--- a/demo/extensibility.ipynb
+++ b/demo/extensibility.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7ffc6c0c-f1a7-472d-8990-75ed8056322a",
+   "metadata": {},
+   "source": [
+    "## Extensibility\n",
+    "You can give Bob more abilities by adding function tools. These are Python functions that consume multiple parameters of basic types such as string, int and float. The function needs a docstring explaining what the function does. This docstring serves the language model to make use of the function when the description of the task fits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fbe2c94e-19d2-4b71-b7b2-457733fee70f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.2.0'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from bia_bob import bob\n",
+    "bob.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d08bcb04-9df3-462e-a808-298fc6db8863",
+   "metadata": {},
+   "source": [
+    "We give Bob a task it cannot handle and it will respond with an error message:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6546ea96-abee-43b6-8ec0-1bf4d35d8c19",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "I'm sorry, but I couldn't find the folders or files named \"A\" and \"B\" to combine. Please make sure the folders and files exist and try again."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%bob combine A and B"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c153adef-a821-4928-beef-282decfbfecd",
+   "metadata": {},
+   "source": [
+    "We now add a function to Bob's toolbox..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "df347e82-6951-475d-b549-a9d015b9731b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "@bob.add_function_tool\n",
+    "def combine(text1:str, text2:str)->str:\n",
+    "    \"\"\"Useful for combining two texts.\"\"\"\n",
+    "    return text1 + \" and \" + text2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75e6da62-a8d8-4f8b-839c-410e468be3eb",
+   "metadata": {},
+   "source": [
+    "And ask for the same task again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b8b46592-28bd-4663-b845-ba809522f85e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The combination of \"A\" and \"B\" is \"A and B\"."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%bob combine A and B"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb8acbf7-b842-4be7-95f5-05e83c8d934d",
+   "metadata": {},
+   "source": [
+    "Note: After adding a tool to Bob, it is reinitialized. It may have forgotten what you told it before."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/bia_bob/__init__.py
+++ b/src/bia_bob/__init__.py
@@ -3,7 +3,8 @@ __version__ = "0.2.0"
 __all__ = (
     )
 
-from ._machinery import bob, init_assistant
+from ._machinery import bob, init_assistant, add_function_tool
 bob.initialize = init_assistant
+bob.add_function_tool = add_function_tool
 
 bob.__version__ = __version__

--- a/src/bia_bob/_machinery.py
+++ b/src/bia_bob/_machinery.py
@@ -77,3 +77,20 @@ def init_assistant(variables, temperature=0):
 
 
 init_assistant(globals())
+
+def add_function_tool(callable):
+    """
+    Adds a function tool to the agent.
+
+    The given callable must have parameters of type string, int and float.
+    It must have a docstring that describes the function, ideally explaining what the function is useful for using
+    terms from the target audience.
+
+    After calling this function, the agent is re-initialized.
+    """
+    from langchain.tools import StructuredTool
+
+    _context.tools.append(StructuredTool.from_function(callable))
+
+    if _context.agent is not None:
+        init_assistant(_context.variables)


### PR DESCRIPTION
This adds a simple mechanism to extend Bob's toolbox. In very short, you can add tools to Bob's toolbox like this:

```
@bob.add_function_tool
def combine(text1:str, text2:str)->str:
    """Useful for combining two texts."""
    return text1 + " and " + text2
```

[See example notebook](https://github.com/haesleinhuepf/bia-bob/blob/edb9b9a6b1869c51151ee996c2aea14ed649d5db/demo/extensibility.ipynb)

* This enables faster prototyping of new functions
* Partly solves #4 but is some kind of workaround
