### PR TITLE
Ensure LLM infrastructure initialization in `ask_llm` to prevent `NoneType` error.

### DIFF
--- a/src/bia_bob/_utilities.py
+++ b/src/bia_bob/_utilities.py
@@ -3,7 +3,9 @@ from functools import lru_cache
 
 def ask_llm(prompt, image=None, chat_history=[]):
     """Ask the language model a simple question and return the response."""
-    from ._machinery import Context
+    from ._machinery import Context, init_assistant
+    if Context.model is None:
+        init_assistant()
     return generate_response(chat_history=chat_history,
                       image=image,
                       model=Context.model,


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.2.3, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

The changes address the issue where the `ask_llm` function was called before the LLM infrastructure was initialized, leading to a `NoneType` error. To solve this, the `ask_llm` function in `src/bia_bob/_utilities.py` was modified to check if the model is initialized and, if not, call `init_assistant()` to set up the necessary LLM infrastructure. This ensures the model is always ready when `ask_llm` is invoked, preventing the error from occurring.

closes #190