### PR TITLE
Initialize LLM infrastructure in `ask_llm` to prevent `NoneType` error.

### DIFF
--- a/src/bia_bob/_utilities.py
+++ b/src/bia_bob/_utilities.py
@@ -3,7 +3,9 @@ from functools import lru_cache
 
 def ask_llm(prompt, image=None, chat_history=[]):
     """Ask the language model a simple question and return the response."""
-    from ._machinery import Context
+    from ._machinery import Context, init_assistant
+    if Context.model is None:
+        init_assistant()
     return generate_response(chat_history=chat_history,
                       image=image,
                       model=Context.model,


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.2.3, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

The changes made ensure that the LLM infrastructure is properly initialized before generating a response in the `ask_llm` function. In `src/bia_bob/_utilities.py`, the `init_assistant` function is called if `Context.model` is `None`, preventing the `NoneType` error when the function is invoked. This resolves the issue where the model context was not being set initially.

closes #190