### PR TITLE
fix unbound variable error

### DIFF
--- a/src/bia_bob/_utilities.py
+++ b/src/bia_bob/_utilities.py
@@ -201,6 +201,7 @@ def generate_code_samples():
         additional_instructions = []
         # Iterate over discovered entry points and load them
         for ep in bia_bob_plugins:
+            instructions = ""
             try:
                 func = ep.load()
 


### PR DESCRIPTION
This fixes an issue in case bia-bob plugins crash while reporting code snippets

closes #199
closes #198 
closes #197 
