### PR TITLE
Use model `alias-large` for blablador in custom_endpoints.ipynb

### DIFF
--- a/demo/custom_endpoints.ipynb
+++ b/demo/custom_endpoints.ipynb
@@ -113,7 +113,7 @@
    "source": [
     "bob.initialize(\n",
     "    endpoint='blablador', \n",
-    "    model='alias-code')"
+    "    model='alias-large')"
    ]
   },
   {


### PR DESCRIPTION
When I used blablador, the model `alias-code` did not produce useful output with bia-bob (neither did `alias-fast`), but the model `alias-large` worked well.

Therefore, I recommend using `alias-large` in this example.