### PR TITLE
Update google_colab.ipynb

### DIFF
--- a/demo/google_colab.ipynb
+++ b/demo/google_colab.ipynb
@@ -104,7 +104,7 @@
    },
    "outputs": [],
    "source": [
-    "bob.initialize(endpoint='ollama', model='gemma3:4b', api_key='')"
+    "bob.initialize(endpoint='ollama', model='gemma3:4b')"
    ]
   },
   {


### PR DESCRIPTION
remove `api_key=''` which is not needed in 0.34.3

as #261 is fixed now, this workaround is not needed anymore.